### PR TITLE
imagePath is not null even if mode is CaptureMode.screen

### DIFF
--- a/lib/src/system_screen_capturer_impl_windows.dart
+++ b/lib/src/system_screen_capturer_impl_windows.dart
@@ -77,7 +77,6 @@ class SystemScreenCapturerImplWindows extends SystemScreenCapturer {
     bool silent = true,
   }) async {
     if (mode == CaptureMode.screen) {
-      assert(imagePath == null);
       await ScreenCapturerPlatform.instance.captureScreen(
         imagePath: imagePath!,
       );


### PR DESCRIPTION
It works if assert(imagePath == null) is not exists.