### PR TITLE
fix: build in web environment

### DIFF
--- a/lib/src/system_screen_capturer_impl_windows_noop.dart
+++ b/lib/src/system_screen_capturer_impl_windows_noop.dart
@@ -3,5 +3,5 @@ import 'package:flutter/services.dart';
 import 'package:screen_capturer/src/system_screen_capturer.dart';
 
 class SystemScreenCapturerImplWindows extends SystemScreenCapturer {
-  SystemScreenCapturerImplWindows(MethodChannel methodChannel);
+  SystemScreenCapturerImplWindows();
 }


### PR DESCRIPTION
```
screen_capturer-0.1.5/lib/src/screen_capturer.dart:23:62: Error: Too few positional arguments: 1 required, 0 given.
      _systemScreenCapturer = SystemScreenCapturerImplWindows();
lib/src/system_screen_capturer_impl_windows_noop.dart:6:3: Context: Found this candidate, but the arguments don't match.
  SystemScreenCapturerImplWindows(MethodChannel methodChannel);
```
fix: build in web