### PR TITLE
新增支持Deepin

### DIFF
--- a/packages/screen_capturer_linux/lib/src/commands/deepin_screen_recorder.dart
+++ b/packages/screen_capturer_linux/lib/src/commands/deepin_screen_recorder.dart
@@ -1,0 +1,40 @@
+import 'dart:io';
+
+import 'package:screen_capturer_platform_interface/screen_capturer_platform_interface.dart';
+import 'package:shell_executor/shell_executor.dart';
+
+final Map<CaptureMode, List<String>> _knownCaptureModeArgs = {
+  CaptureMode.region: [''],
+  CaptureMode.screen: ['-f'],
+  CaptureMode.window: ['--dograb'],
+};
+
+class _Deepin extends Command with SystemScreenCapturer {
+  @override
+  String get executable {
+    return 'deepin-screen-recorder';
+  }
+
+  @override
+  Future<void> install() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<ProcessResult> capture({
+    required CaptureMode mode,
+    String? imagePath,
+    bool copyToClipboard = true,
+    bool silent = true,
+  }) {
+    return exec(
+      [
+        ..._knownCaptureModeArgs[mode]!,
+        ...(imagePath != null ? ['-s', imagePath] : []),
+        ...(silent ? ['-n'] : []),
+      ],
+    );
+  }
+}
+
+final deepinScreenRecorder = _Deepin();

--- a/packages/screen_capturer_linux/lib/src/screen_capturer_linux.dart
+++ b/packages/screen_capturer_linux/lib/src/screen_capturer_linux.dart
@@ -32,7 +32,8 @@ class ScreenCapturerLinux extends MethodChannelScreenCapturer {
   bool get isDeepinDesktop {
     if (_isDeepinDesktop == null) {
       try {
-        final result = ShellExecutor.global.execSync('deepin-screen-recorder', ['-v']);
+        final result =
+            ShellExecutor.global.execSync('deepin-screen-recorder', ['-v']);
         _isDeepinDesktop = result.exitCode == 0;
       } catch (_) {
         _isDeepinDesktop = false;

--- a/packages/screen_capturer_linux/lib/src/screen_capturer_linux.dart
+++ b/packages/screen_capturer_linux/lib/src/screen_capturer_linux.dart
@@ -1,3 +1,4 @@
+import 'package:screen_capturer_linux/src/commands/deepin_screen_recorder.dart';
 import 'package:screen_capturer_linux/src/commands/gnome_screenshot.dart';
 import 'package:screen_capturer_linux/src/commands/spectacle.dart';
 import 'package:screen_capturer_platform_interface/screen_capturer_platform_interface.dart';
@@ -26,10 +27,28 @@ class ScreenCapturerLinux extends MethodChannelScreenCapturer {
     return _isKdeDesktop!;
   }
 
+  bool? _isDeepinDesktop;
+
+  bool get isDeepinDesktop {
+    if (_isDeepinDesktop == null) {
+      try {
+        final result = ShellExecutor.global.execSync('deepin-screen-recorder', ['-v']);
+        _isDeepinDesktop = result.exitCode == 0;
+      } catch (_) {
+        _isDeepinDesktop = false;
+      }
+    }
+    return _isDeepinDesktop!;
+  }
+
   @override
   SystemScreenCapturer get systemScreenCapturer {
     if (isKdeDesktop) {
       return spectacle;
+    }
+
+    if (isDeepinDesktop) {
+      return deepinScreenRecorder;
     }
     return gnomeScreenshot;
   }


### PR DESCRIPTION
```
➜ deepin-screen-recorder --help-all
isDeepin:  true
isDDE:  true
SystemName:  "深度操作系统"
EditionName:  "社区版"
ProductTypeName:  "桌面"
SystemVersion:  "23"
Is Table: false
Is Wayland: false
Is Root User: false
where is libs? where is  QDir( "/usr/lib/x86_64-linux-gnu" , nameFilters = { "*" },  QDir::SortFlags( Name | IgnoreCase ) , QDir::Filters( Dirs|Files|Drives|AllEntries ) )
Is libavcodec in there?  there is : ("libavcodec.so.60", "libavcodec.so.60.31.102")
Is exists ffmpeg in PATH( "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:/home/iAkii/.local/share/pnpm:/home/iAkii/.flutter/bin:/home/iAkii/.cargo/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games:/sbin:/usr/sbin:/home/iAkii/.pub-cache/bin" ): true
Is FFmpeg Environment: true
KF5_WAYLAND_FLAGE_ON is close!!
Usage: deepin-screen-recorder [options]
deepin-screen-recorder

Options:
  -h, --help                                       Displays help on commandline
                                                   options.
  --help-all                                       Displays help including Qt
                                                   specific options.
  -v, --version                                    Displays version
                                                   information.
  -d, --delay <NUM>                                Take a screenshot after NUM
                                                   seconds.
  -f, --fullscreen                                 Take a screenshot the whole
                                                   screen.
  -w, --top-window                                 Take a screenshot of the
                                                   most top window.
  -s, --save-path <PATH>                           Specify a path to save the
                                                   screenshot.
  -n, --no-notification                            Don't send notifications.
  -g, --gstreamer                                  Use GStreamer.
  -u, --dbus                                       Start  from dbus.
  --record, --screenRecord, --start screen record
  --shot, --screenShot, --start screen shot
  --ocr, --screenOcr, --start screen ocr
  --scroll, --screenScroll, --start screen scroll
  --qmljsdebugger <value>                          Activates the QML/JS
                                                   debugger with a specified
                                                   port. The value must be of
                                                   format port:1234[,block].
                                                   "block" makes the application
                                                   wait for a connection.
  --platform <platformName[:options]>              QPA plugin. See
                                                   QGuiApplication documentation
                                                   for available options for
                                                   each plugin.
  --platformpluginpath <path>                      Path to the platform
                                                   plugins.
  --platformtheme <theme>                          Platform theme.
  --plugin <plugin>                                Additional plugins to load,
                                                   can be specified multiple
                                                   times.
  --qwindowgeometry <geometry>                     Window geometry for the main
                                                   window, using the X11-syntax,
                                                   like 100x100+50+50.
  --qwindowicon <icon>                             Default window icon.
  --qwindowtitle <title>                           Title of the first window.
  --reverse                                        Sets the application's
                                                   layout direction to
                                                   Qt::RightToLeft (debugging
                                                   helper).
  --session <session>                              Restores the application
                                                   from an earlier session.
  --display <display>                              Display name, overrides
                                                   $DISPLAY.
  --name <name>                                    Instance name according to
                                                   ICCCM 4.1.2.5.
  --nograb                                         Disable mouse grabbing
                                                   (useful in debuggers).
  --dograb                                         Force mouse grabbing (even
                                                   when running in a debugger).
  --visual <id>                                    ID of the X11 Visual to use.
  --geometry <geometry>                            Alias for --qwindowgeometry.
  --icon <icon>                                    Alias for --qwindowicon.
  --title <title>                                  Alias for --qwindowtitle.
```